### PR TITLE
Realign messaging authentication with backend

### DIFF
--- a/ClearBlade.js
+++ b/ClearBlade.js
@@ -1206,7 +1206,7 @@ if (!window.console) {
     //roll through the config
     var conf = {};
     conf.userName = ClearBlade.user.authToken;
-    conf.password = ClearBlade.systemSecret;
+    conf.password = ClearBlade.systemKey;
     conf.cleanSession = options.cleanSession || true;
     conf.useSSL = options.useSSL || false; //up for debate. ole' perf vs sec argument
     conf.hosts = options.hosts || [ClearBlade.messagingURI];


### PR DESCRIPTION
Miscommunication, we use the key, not the secret as a part of the authentication scheme.
