### PR TITLE
Fixed query fetch callback to return correct error string

### DIFF
--- a/ClearBlade.js
+++ b/ClearBlade.js
@@ -520,15 +520,11 @@ if (!window.console) {
    */
 
    var _createItemList = function(err, data, options, callback) {
-    if (err) {
-      callback(err, data);
-    } else {
-      var itemArray = [];
-      for (var i = 0; i < data.length; i++) {
-        itemArray.push(ClearBlade.prototype.Item(data[i], options));
-      }
-      callback(err, itemArray);
+    var itemArray = [];
+    for (var i = 0; i < data.length; i++) {
+      itemArray.push(ClearBlade.prototype.Item(data[i], options));
     }
+    callback(err, itemArray);
    };
 
   var _request = function (options, callback) {
@@ -779,7 +775,11 @@ if (!window.console) {
       };
 
       var callCallback = function (err, data) {
-        _createItemList(err, data.DATA, options, callback);
+        if(err) {
+          callback(err, data);
+        } else {
+          _createItemList(err, data.DATA, options, callback);
+        }
       };
       if (typeof callback === 'function') {
         ClearBlade.request(reqOptions, callCallback);
@@ -1196,7 +1196,7 @@ if (!window.console) {
       };
       var callCallback = function (err, data) {
         if(err) {
-          _createItemList(err, data, options, callback);
+          callback(err, data);
         } else {
           _createItemList(err, data.DATA, options, callback);
         }

--- a/ClearBlade.js
+++ b/ClearBlade.js
@@ -520,11 +520,15 @@ if (!window.console) {
    */
 
    var _createItemList = function(err, data, options, callback) {
-    var itemArray = [];
-    for (var i = 0; i < data.length; i++) {
-      itemArray.push(ClearBlade.prototype.Item(data[i], options));
+    if(data !== undefined) {
+      var itemArray = [];
+      for (var i = 0; i < data.length; i++) {
+        itemArray.push(ClearBlade.prototype.Item(data[i], options));
+      }
+      callback(err, itemArray);
+    } else {
+      callback(true, "There was some problem. Data is undefined");
     }
-    callback(err, itemArray);
    };
 
   var _request = function (options, callback) {

--- a/ClearBlade.js
+++ b/ClearBlade.js
@@ -1195,7 +1195,11 @@ if (!window.console) {
         URI: this.URI
       };
       var callCallback = function (err, data) {
-        _createItemList(err, data.DATA, options, callback);
+        if(err) {
+          _createItemList(err, data, options, callback);
+        } else {
+          _createItemList(err, data.DATA, options, callback);
+        }
       };
 
       if (typeof callback === 'function') {


### PR DESCRIPTION
The query fetch callback returned data.DATA for both err true and false. Fixed that to return data when err is true and data.DATA when err is false.